### PR TITLE
Allow using partial select from cli

### DIFF
--- a/src/cli/context.ts
+++ b/src/cli/context.ts
@@ -39,6 +39,7 @@ export const resolveCLIContext = (input: Input): CLIContext => {
 };
 
 type CLIOperationInput = {
+  allowPartialSelection: boolean;
   autoFixableOnly: boolean;
   limit: string;
   limitType: string;
@@ -70,6 +71,7 @@ export const resolveCLIOperation = (input: CLIOperationInput): CLIOperation => {
   return {
     limit,
     options: {
+      allowPartialSelection: input.allowPartialSelection,
       autoFixableOnly: input.autoFixableOnly,
     },
   };

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -41,6 +41,13 @@ const cli = defineCommand({
     },
 
     // operation options
+    "allow-partial-selection": {
+      description:
+        "Allow partial selection of violations. Only works with --correct. (default: false)",
+      required: false,
+      type: "boolean",
+      valueHint: "boolean",
+    },
     "auto-fixable-only": {
       default: true,
       description: "Only handle auto-fixable violations. (default: true)",
@@ -103,6 +110,7 @@ const cli = defineCommand({
         correct: args.correct,
       },
       operation: {
+        allowPartialSelection: args["allow-partial-selection"],
         autoFixableOnly: args["auto-fixable-only"],
         limit: args.limit,
         limitType: args["limit-type"],

--- a/src/operation/selectRule.test.ts
+++ b/src/operation/selectRule.test.ts
@@ -719,6 +719,26 @@ describe("selectRuleBasedOnViolationsLimit", () => {
         expect(result).toStrictEqual(expected);
       });
 
+      it("should return success: false if no available partial", () => {
+        const todoModule = createTodoModuleV2({
+          rule1: {
+            autoFix: true,
+            violations: {
+              "file1.js": 3,
+            },
+          },
+        });
+        const limit: OperationViolationLimit = { count: 2, type: "violation" };
+        const expected: SelectionResult = { success: false };
+
+        const result = selectRuleBasedOnViolationsLimit(
+          todoModule,
+          limit,
+          operationOptions,
+        );
+        expect(result).toStrictEqual(expected);
+      });
+
       it("should return success: false if todo is empty", () => {
         const todoModule = createTodoModuleV2({});
         const limit: OperationViolationLimit = { count: 1, type: "violation" };
@@ -914,6 +934,26 @@ describe("selectRuleBasedOnViolationsLimit", () => {
           },
           success: true,
         };
+
+        const result = selectRuleBasedOnViolationsLimit(
+          todoModule,
+          limit,
+          operationOptions,
+        );
+        expect(result).toStrictEqual(expected);
+      });
+
+      it("should return success: false if no available partial", () => {
+        const todoModule = createTodoModuleV2({
+          rule1: {
+            autoFix: false,
+            violations: {
+              "file1.js": 3,
+            },
+          },
+        });
+        const limit: OperationViolationLimit = { count: 2, type: "violation" };
+        const expected: SelectionResult = { success: false };
 
         const result = selectRuleBasedOnViolationsLimit(
           todoModule,

--- a/src/operation/selectRule.ts
+++ b/src/operation/selectRule.ts
@@ -229,6 +229,22 @@ export const selectRuleBasedOnViolationsLimit = (
       selectedViolations[file] = count;
     }
 
+    // todo: {
+    //   rule1: {
+    //     autoFix: true,
+    //     violations: {
+    //       "file1.js": 3,
+    //     },
+    //   },
+    // }
+    // { limit: 2 }
+    //
+    // when this kind of situation occurs, no partial selection could be made
+    // so we should return { success: false }
+    if (Object.keys(selectedViolations).length === 0) {
+      return { success: false };
+    }
+
     return {
       selection: {
         ruleId: partialSelectableRule,


### PR DESCRIPTION
- issue: #9

- todo: partial delete support
---

- [x] add `--allow-partial-selection` flag
- [x] passing partial selection to selectRule operation
- [x] add missing test for [selectRuleBasedOnViolationsLimit](https://github.com/sushichan044/eslint-todo/commit/6cc4f9b88700559ffced126b6c5b7603dac04618)