### PR TITLE
fix: remove ci from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,12 +15,8 @@ permissions:
   contents: read
 
 jobs:
-  ci:
-    uses: ./.github/workflows/ci.yml
-
   build-and-publish:
     name: Build and Publish
-    needs: ci
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     permissions:


### PR DESCRIPTION
Since the release workflow is started manually, CI should already have been performed on the latest commit at the time of startup.
In other words, there is no need to run CI in the release workflow.