### PR TITLE
feat: use deep partial for all types of options

### DIFF
--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -44,6 +44,18 @@ export default typegen(
               ],
             },
           ],
+          "@typescript-eslint/no-restricted-types": [
+            "error",
+            {
+              types: {
+                Partial: {
+                  message:
+                    "Consider using `DeepPartial` from `utils/types` instead",
+                  suggest: ["DeepPartial"],
+                },
+              },
+            },
+          ],
           "no-restricted-imports": "off",
         },
       },

--- a/src/operation/options.ts
+++ b/src/operation/options.ts
@@ -1,5 +1,7 @@
 import defu from "defu";
 
+import type { DeepPartial } from "../utils/types";
+
 export type OperationOptions = {
   /**
    * Only handle auto-fixable violations.
@@ -16,7 +18,7 @@ export type OperationOptions = {
   allowPartialSelection: boolean;
 };
 
-export type UserOperationOptions = Partial<OperationOptions>;
+export type UserOperationOptions = DeepPartial<OperationOptions>;
 
 /**
  * @package

--- a/src/options.ts
+++ b/src/options.ts
@@ -1,6 +1,8 @@
 import { defu } from "defu";
 import { cwd } from "node:process";
 
+import type { DeepPartial } from "./utils/types";
+
 export type Options = {
   /**
    * The file path to read and write the ESLint todo list.
@@ -16,7 +18,7 @@ export type Options = {
   cwd: string;
 };
 
-export type UserOptions = Partial<Options>;
+export type UserOptions = DeepPartial<Options>;
 
 /**
  * @package

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -9,3 +9,12 @@ export type MaybePromisifyAllMethods<T> = {
 };
 
 export type IsNever<T> = T[] extends never[] ? true : false;
+
+export type DeepPartial<T> =
+  T extends Record<PropertyKey, unknown>
+    ? {
+        [K in keyof T]?: T[K] extends Record<PropertyKey, unknown>
+          ? DeepPartial<T[K]>
+          : T[K];
+      }
+    : T;


### PR DESCRIPTION
Added a countermeasure for the configuration objects that users will use in the future that have a depth of 2 or greater.