### PR TITLE
refactor: replace runAction with prepareAction for better action execution handling

### DIFF
--- a/src/cli/action/index.test.ts
+++ b/src/cli/action/index.test.ts
@@ -3,9 +3,11 @@ import type { Mock } from "vitest";
 import consola from "consola";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
+import type { CLIAction } from "./index";
+
 import { configWithDefault } from "../../config/config";
 import { launchRemoteESLintTodoCore } from "../../remote/client";
-import { runAction } from "./index";
+import { prepareAction } from "./index";
 
 consola.mockTypes(() => vi.fn());
 
@@ -13,7 +15,7 @@ vi.mock("../../remote/client", () => ({
   launchRemoteESLintTodoCore: vi.fn(),
 }));
 
-describe("runAction", () => {
+describe("prepareAction", () => {
   const mockCore = {};
   const mockRemoteService = {
     RemoteESLintTodoCore: vi.fn().mockResolvedValue(mockCore),
@@ -32,51 +34,82 @@ describe("runAction", () => {
     (launchRemoteESLintTodoCore as Mock).mockReturnValue(mockRemoteService);
   });
 
-  it("should not pass input to action if input is not provided", async () => {
-    const action = vi.fn();
-    const config = configWithDefault();
-    await runAction(action, { config, consola });
+  describe("Prepared Action Input and Output", () => {
+    it("should not accept input if action has no input", async () => {
+      const actionWithNoInputs = vi.fn<CLIAction<never>>();
+      const config = configWithDefault();
+      const preparedAction = prepareAction(actionWithNoInputs, {
+        config,
+        consola,
+      });
+      await preparedAction();
 
-    expect(action).toHaveBeenCalledExactlyOnceWith({
-      config,
-      core: mockCore,
-      logger: consola,
+      expect(actionWithNoInputs).toHaveBeenCalledExactlyOnceWith({
+        config,
+        core: mockCore,
+        logger: consola,
+      });
+    });
+
+    it("should accept input of action and return output of action", async () => {
+      const actionWithInputs = vi
+        .fn<CLIAction<"input", "result">>()
+        .mockResolvedValue("result");
+      const config = configWithDefault();
+      const preparedAction = prepareAction(actionWithInputs, {
+        config,
+        consola,
+      });
+
+      const result = await preparedAction("input");
+      expect(actionWithInputs).toHaveBeenCalledExactlyOnceWith(
+        {
+          config,
+          core: mockCore,
+          logger: consola,
+        },
+        "input",
+      );
+      expect(result).toBe("result");
     });
   });
 
   describe("When action is succeed", () => {
-    it("should return action result", async () => {
-      const action = vi.fn().mockResolvedValue("result");
-      const config = configWithDefault();
+    it("should call remoteService.terminate after action is resolved", async () => {
+      const action = vi.fn<CLIAction<never, null>>().mockResolvedValue(null);
 
-      const result = await runAction<"result">(action, {
-        config,
+      const preparedAction = prepareAction(action, {
+        config: configWithDefault(),
         consola,
       });
-      expect(result).toBe("result");
-    });
-
-    it("should call remoteService.terminate after action is resolved", async () => {
-      const action = vi.fn().mockResolvedValue(null);
-
-      await runAction(action, { config: configWithDefault(), consola });
+      await preparedAction();
       expect(mockRemoteService.terminate).toHaveBeenCalledOnce();
     });
   });
 
   describe("When action is failed", () => {
     it("should call consola.error and rethrow error if action throws", async () => {
-      const action = vi.fn().mockRejectedValue(new TestError());
+      const action = vi
+        .fn<CLIAction<never>>()
+        .mockRejectedValue(new TestError());
 
-      await expect(
-        runAction(action, { config: configWithDefault(), consola }),
-      ).rejects.toThrow(TestError);
+      const preparedAction = prepareAction(action, {
+        config: configWithDefault(),
+        consola,
+      });
+      await expect(preparedAction()).rejects.toThrow(TestError);
       expect(consola.error).toHaveBeenCalledOnce();
     });
 
     it("should call remoteService.terminate after action is rejected", async () => {
-      const action = vi.fn().mockRejectedValue(new TestError());
-      await runAction(action, { config: configWithDefault(), consola }).catch(
+      const action = vi
+        .fn<CLIAction<never>>()
+        .mockRejectedValue(new TestError());
+      const preparedAction = prepareAction(action, {
+        config: configWithDefault(),
+        consola,
+      });
+      await preparedAction().catch(
         // eslint-disable-next-line @typescript-eslint/no-empty-function
         () => {},
       );


### PR DESCRIPTION
By separating the preparation and execution of CLI actions, we have made it difficult to increase complexity, even if the number of elements that can be passed at the time of preparation for execution increases in the future.