### PR TITLE
build: remove typia import from final bundle

### DIFF
--- a/build.config.ts
+++ b/build.config.ts
@@ -23,4 +23,7 @@ export default defineBuildConfig({
       options.plugins.unshift(typiaRollup);
     },
   },
+  rollup: {
+    inlineDependencies: true,
+  },
 });

--- a/package.json
+++ b/package.json
@@ -60,8 +60,7 @@
     "jiti": "2.4.2",
     "klona": "2.0.6",
     "magicast": "0.3.5",
-    "pathe": "2.0.3",
-    "typia": "8.1.1"
+    "pathe": "2.0.3"
   },
   "devDependencies": {
     "@eslint/config-inspector": "1.0.2",
@@ -90,6 +89,7 @@
     "ts-patch": "3.3.0",
     "typescript": "5.8.2",
     "typescript-eslint": "8.28.0",
+    "typia": "8.1.1",
     "unbuild": "3.5.0",
     "vite": "6.2.4",
     "vite-node": "3.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,9 +41,6 @@ importers:
       pathe:
         specifier: 2.0.3
         version: 2.0.3
-      typia:
-        specifier: 8.1.1
-        version: 8.1.1(@samchon/openapi@3.2.2)(typescript@5.8.2)
     devDependencies:
       '@eslint/config-inspector':
         specifier: 1.0.2
@@ -123,6 +120,9 @@ importers:
       typescript-eslint:
         specifier: 8.28.0
         version: 8.28.0(eslint@9.23.0(jiti@2.4.2))(typescript@5.8.2)
+      typia:
+        specifier: 8.1.1
+        version: 8.1.1(@samchon/openapi@3.2.2)(typescript@5.8.2)
       unbuild:
         specifier: 3.5.0
         version: 3.5.0(typescript@5.8.2)


### PR DESCRIPTION
Marking typia as a final dependency requires pnpm 10 or higher to allow lifecycle scripts.
There is almost no import of typia needed at runtime, so it should be inlined and delivered.