### PR TITLE
build: generate json schema after build

### DIFF
--- a/scripts/json-schema.ts
+++ b/scripts/json-schema.ts
@@ -1,8 +1,19 @@
+/**
+ * @fileoverview Generate JSON schema and add it to the build artifacts.
+ *
+ * IMPORTANT:
+ * This script requires `unplugin-typia` to work.
+ * So you need to run this script via `pnpm run build:json-schema`.
+ */
+
 import * as fs from "fs-extra/esm";
-import { cwd } from "node:process";
-import { join } from "pathe";
+import { join, resolve } from "pathe";
 
 import { UserConfigJsonSchema } from "../src/config/json";
+
+const getRepoRoot = () => {
+  return resolve(import.meta.dirname, "..");
+};
 
 /**
  * Generate JSON schema and add it to the build artifacts.
@@ -23,4 +34,4 @@ const generateJsonSchemaFile = async (outputDirectory: string) => {
   );
 };
 
-await generateJsonSchemaFile(cwd());
+await generateJsonSchemaFile(getRepoRoot());

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -26,8 +26,12 @@ export default defineConfig({
         await sh(["pnpm", "run", "build:json-schema"]);
         console.log("✅ JSON schema generated successfully");
       } catch (error) {
-        console.error("❌ Failed to generate JSON schema:", error.message);
-        throw error; // Re-throw to fail the build if schema generation is critical
+        if (error instanceof Error) {
+          console.error("❌ Failed to generate JSON schema:", error.message);
+        } else {
+          console.error("❌ Failed to generate JSON schema:", String(error));
+        }
+        throw error;
       }
     },
   },

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -1,6 +1,7 @@
 import NodeExternals from "rollup-plugin-node-externals";
 import { defineConfig } from "tsdown";
 
+import { sh } from "./src/utils/command";
 import { typiaRolldown } from "./typia-plugin";
 
 export default defineConfig({
@@ -19,6 +20,11 @@ export default defineConfig({
     "!./src/worker/**/*.test.ts",
   ],
   format: "esm",
+  hooks: {
+    "build:done": async () => {
+      await sh(["pnpm", "run", "build:json-schema"]);
+    },
+  },
   minify: "dce-only",
   outDir: "dist",
   outExtensions: () => {

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -22,7 +22,13 @@ export default defineConfig({
   format: "esm",
   hooks: {
     "build:done": async () => {
-      await sh(["pnpm", "run", "build:json-schema"]);
+      try {
+        await sh(["pnpm", "run", "build:json-schema"]);
+        console.log("✅ JSON schema generated successfully");
+      } catch (error) {
+        console.error("❌ Failed to generate JSON schema:", error.message);
+        throw error; // Re-throw to fail the build if schema generation is critical
+      }
     },
   },
   minify: "dce-only",


### PR DESCRIPTION
Forgot to setup this when migrating into tsdown.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated script to generate JSON schema files in the repository root directory.
  - Added a post-build step to automatically run JSON schema generation after each build.
- **Documentation**
  - Included a file-level comment in the JSON schema script describing its purpose and usage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->