### PR TITLE
ci: use oidc trusted publication

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,4 +1,4 @@
-name: Release
+name: Publish to npm
 
 on:
   workflow_dispatch:
@@ -17,6 +17,7 @@ permissions:
 jobs:
   build-and-publish:
     name: Build and Publish
+    if: github.repository == 'sushichan044/eslint-todo'
     runs-on: ubuntu-24.04
     timeout-minutes: 10
     permissions:
@@ -37,9 +38,12 @@ jobs:
         with:
           registry-url: "https://registry.npmjs.org"
 
+      - name: Setup latest npm to use OIDC trusted publish
+        run: |
+          # https://docs.npmjs.com/trusted-publishers requires npm 11.5.1 or later
+          pnpm install -g npm@^11.5.1
+
       - name: Release
         run: pnpm exec release-it
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          NPM_CONFIG_PROVENANCE: "true"


### PR DESCRIPTION
Migrate into OIDC trusted publish.
https://docs.npmjs.com/trusted-publishers

- [ ] Delete token from actions secret after publish succeed