### PR TITLE
chore: drop support of node <20.12 and 23

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Requires:
   - **Flat Config Required**
   - If you are using legacy config, you must migrate into flat config first.
     - Utilities like [@eslint/compat](https://github.com/eslint/rewrite/tree/main/packages/compat) can help you.
-- Node.js: `>= 20.0.0`
+- Node.js: `^20.12.0 || ^22.0.0 || >=24.0.0`
   - May work in Deno, but not tested.
 
 ## Getting Started

--- a/package.json
+++ b/package.json
@@ -120,7 +120,7 @@
   },
   "packageManager": "pnpm@10.13.1",
   "engines": {
-    "node": "^20.0.0 || ^22.0.0 || ^23.0.0"
+    "node": "^20.12.0 || ^22.0.0 || >=24.0.0"
   },
   "pnpm": {
     "onlyBuiltDependencies": [


### PR DESCRIPTION
- node 23 is deprecated
- node <20.12 is missing `utils.styleText`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Node.js version requirements to support only specific versions (20.12.0 and above, 22.x, and 24.0.0 or higher), removing support for Node.js 23.x and earlier 20.x releases.
  * Updated documentation to reflect the new Node.js version requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->