### PR TITLE
fix: refine FlattenObject<T> type

### DIFF
--- a/src/utils/flatten.test-d.ts
+++ b/src/utils/flatten.test-d.ts
@@ -189,4 +189,54 @@ describe("FlattenObject", () => {
       }>();
     });
   });
+
+  describe("negative and boundary cases", () => {
+    it("should return never for top-level arrays", () => {
+      expectTypeOf<FlattenObject<string[]>>().toEqualTypeOf<never>();
+      expectTypeOf<FlattenObject<number[]>>().toEqualTypeOf<never>();
+      expectTypeOf<FlattenObject<readonly boolean[]>>().toEqualTypeOf<never>();
+    });
+
+    it("should return never for top-level functions", () => {
+      expectTypeOf<FlattenObject<() => void>>().toEqualTypeOf<never>();
+      expectTypeOf<
+        FlattenObject<(x: string) => number>
+      >().toEqualTypeOf<never>();
+    });
+
+    it("should ignore numeric-indexed keys and only flatten string keys", () => {
+      expectTypeOf<FlattenObject<{ 0: string; one: number }>>().toEqualTypeOf<{
+        one: number;
+      }>();
+
+      expectTypeOf<
+        FlattenObject<{
+          1: boolean;
+          2: string;
+          anotherKey: { nested: string };
+          validKey: number;
+        }>
+      >().toEqualTypeOf<{
+        "anotherKey.nested": string;
+        "validKey": number;
+      }>();
+    });
+
+    it("should ignore symbol keys and only flatten string keys", () => {
+      const uniqueSymbol = Symbol("unique");
+      type WithSymbol = {
+        a: number;
+        nested: {
+          b: string;
+          [uniqueSymbol]: boolean;
+        };
+        [uniqueSymbol]: string;
+      };
+
+      expectTypeOf<FlattenObject<WithSymbol>>().toEqualTypeOf<{
+        "a": number;
+        "nested.b": string;
+      }>();
+    });
+  });
 });

--- a/src/utils/flatten.test-d.ts
+++ b/src/utils/flatten.test-d.ts
@@ -191,17 +191,19 @@ describe("FlattenObject", () => {
   });
 
   describe("negative and boundary cases", () => {
-    it("should return never for top-level arrays", () => {
-      expectTypeOf<FlattenObject<string[]>>().toEqualTypeOf<never>();
-      expectTypeOf<FlattenObject<number[]>>().toEqualTypeOf<never>();
-      expectTypeOf<FlattenObject<readonly boolean[]>>().toEqualTypeOf<never>();
+    it("should return the array type for top-level arrays", () => {
+      expectTypeOf<FlattenObject<string[]>>().toEqualTypeOf<string[]>();
+      expectTypeOf<FlattenObject<number[]>>().toEqualTypeOf<number[]>();
+      expectTypeOf<FlattenObject<readonly boolean[]>>().toEqualTypeOf<
+        readonly boolean[]
+      >();
     });
 
-    it("should return never for top-level functions", () => {
-      expectTypeOf<FlattenObject<() => void>>().toEqualTypeOf<never>();
-      expectTypeOf<
-        FlattenObject<(x: string) => number>
-      >().toEqualTypeOf<never>();
+    it("should return the function type for top-level functions", () => {
+      expectTypeOf<FlattenObject<() => void>>().toEqualTypeOf<() => void>();
+      expectTypeOf<FlattenObject<(x: string) => number>>().toEqualTypeOf<
+        (x: string) => number
+      >();
     });
 
     it("should ignore numeric-indexed keys and only flatten string keys", () => {

--- a/src/utils/flatten.test-d.ts
+++ b/src/utils/flatten.test-d.ts
@@ -145,4 +145,48 @@ describe("FlattenObject", () => {
       }>();
     });
   });
+
+  describe("discriminated union", () => {
+    it("should handle discriminated union", () => {
+      expectTypeOf<
+        FlattenObject<
+          | {
+              type: "bar";
+              value: { bar: string };
+            }
+          | {
+              type: "foo";
+              value: { foo: string };
+            }
+        >
+      >().toEqualTypeOf<
+        | {
+            "type": "bar";
+            "value.bar": string;
+          }
+        | {
+            "type": "foo";
+            "value.foo": string;
+          }
+      >();
+    });
+
+    it("should handle discriminated union with conditional keys", () => {
+      expectTypeOf<
+        FlattenObject<{
+          a:
+            | {
+                type: "bar";
+              }
+            | {
+                type: "foo";
+                value: string;
+              };
+        }>
+      >().toEqualTypeOf<{
+        "a.type": "bar" | "foo";
+        "a.value": never; // Properties not present in all union branches become never
+      }>();
+    });
+  });
 });

--- a/src/utils/flatten.ts
+++ b/src/utils/flatten.ts
@@ -1,20 +1,28 @@
 type PlainObjectLike = Record<PropertyKey, unknown>;
 
-export type FlattenObject<T> = T extends PlainObjectLike
-  ? {
-      [K in FlattenKeys<T>]: K extends `${infer P}.${infer S}`
-        ? P extends keyof T & string
-          ? T[P] extends PlainObjectLike
-            ? S extends keyof FlattenObject<T[P]>
-              ? FlattenObject<T[P]>[S]
+export type FlattenObject<T> = T extends readonly unknown[]
+  ? T
+  : T extends (...args: any[]) => any
+    ? T
+    : T extends PlainObjectLike
+      ? {
+          [K in FlattenKeys<T>]: K extends `${infer P}.${infer S}`
+            ? P extends keyof T & string
+              ? T[P] extends readonly unknown[]
+                ? T[P]
+                : T[P] extends (...args: any[]) => any
+                  ? T[P]
+                  : T[P] extends PlainObjectLike
+                    ? S extends keyof FlattenObject<T[P]>
+                      ? FlattenObject<T[P]>[S]
+                      : never
+                    : never
               : never
-            : never
-          : never
-        : K extends keyof T & string
-          ? T[K]
-          : never;
-    }
-  : never;
+            : K extends keyof T & string
+              ? T[K]
+              : never;
+        }
+      : never;
 
 type FlattenKeys<T> = T extends PlainObjectLike
   ? {

--- a/src/utils/flatten.ts
+++ b/src/utils/flatten.ts
@@ -1,21 +1,27 @@
-export type FlattenObject<T> = {
-  [K in FlattenKeys<T>]: K extends `${infer P}.${infer S}`
-    ? P extends keyof T
-      ? T[P] extends Record<PropertyKey, unknown>
-        ? S extends keyof FlattenObject<T[P]>
-          ? FlattenObject<T[P]>[S]
-          : never
-        : never
-      : never
-    : K extends keyof T
-      ? T[K]
-      : never;
-};
+type PlainObjectLike = Record<PropertyKey, unknown>;
 
-type FlattenKeys<T, K extends keyof T = keyof T> = K extends string
-  ? T[K] extends readonly unknown[]
-    ? K
-    : T[K] extends Record<PropertyKey, unknown>
-      ? `${K}.${FlattenKeys<T[K]>}`
-      : K
+export type FlattenObject<T> = T extends PlainObjectLike
+  ? {
+      [K in FlattenKeys<T>]: K extends `${infer P}.${infer S}`
+        ? P extends keyof T & string
+          ? T[P] extends PlainObjectLike
+            ? S extends keyof FlattenObject<T[P]>
+              ? FlattenObject<T[P]>[S]
+              : never
+            : never
+          : never
+        : K extends keyof T & string
+          ? T[K]
+          : never;
+    }
+  : never;
+
+type FlattenKeys<T> = T extends PlainObjectLike
+  ? {
+      [K in keyof T & string]: T[K] extends readonly unknown[]
+        ? K
+        : T[K] extends PlainObjectLike
+          ? `${K}.${FlattenKeys<T[K]>}`
+          : K;
+    }[keyof T & string]
   : never;

--- a/src/utils/flatten.ts
+++ b/src/utils/flatten.ts
@@ -1,22 +1,22 @@
 type PlainObjectLike = Record<PropertyKey, unknown>;
 
+type AnyFunction = (...arguments_: never) => unknown;
+
 export type FlattenObject<T> = T extends readonly unknown[]
   ? T
-  : T extends (...args: any[]) => any
+  : T extends AnyFunction
     ? T
     : T extends PlainObjectLike
       ? {
           [K in FlattenKeys<T>]: K extends `${infer P}.${infer S}`
             ? P extends keyof T & string
-              ? T[P] extends readonly unknown[]
+              ? T[P] extends AnyFunction | readonly unknown[]
                 ? T[P]
-                : T[P] extends (...args: any[]) => any
-                  ? T[P]
-                  : T[P] extends PlainObjectLike
-                    ? S extends keyof FlattenObject<T[P]>
-                      ? FlattenObject<T[P]>[S]
-                      : never
+                : T[P] extends PlainObjectLike
+                  ? S extends keyof FlattenObject<T[P]>
+                    ? FlattenObject<T[P]>[S]
                     : never
+                  : never
               : never
             : K extends keyof T & string
               ? T[K]
@@ -26,10 +26,12 @@ export type FlattenObject<T> = T extends readonly unknown[]
 
 type FlattenKeys<T> = T extends PlainObjectLike
   ? {
-      [K in keyof T & string]: T[K] extends readonly unknown[]
+      [K in Extract<keyof T, string>]: T[K] extends readonly unknown[]
         ? K
-        : T[K] extends PlainObjectLike
-          ? `${K}.${FlattenKeys<T[K]>}`
-          : K;
-    }[keyof T & string]
+        : T[K] extends AnyFunction
+          ? K
+          : T[K] extends PlainObjectLike
+            ? `${K}.${FlattenKeys<T[K]>}`
+            : K;
+    }[Extract<keyof T, string>]
   : never;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- Refactor
  - Tightened TypeScript typings for the object-flattening utility: now restricted to plain objects with string keys, treats arrays and functions as terminal leaves, and only recurses into plain-object values — may change type-level behavior for some callers.

- Tests
  - Expanded type-level tests covering discriminated unions, arrays, functions, numeric/symbol key boundaries and other edge cases to ensure predictable flattening.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->