### PR TITLE
build: inherit from Vite

### DIFF
--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -1,7 +1,5 @@
 import { defineConfig } from "tsdown";
 
-import { typiaRolldown } from "./typia-plugin";
-
 export default defineConfig({
   attw: { profile: "esmOnly" },
   clean: true,
@@ -19,6 +17,7 @@ export default defineConfig({
     "!./src/worker/**/*.test.ts",
   ],
   format: "esm",
+  fromVite: true,
   minify: "dce-only",
   nodeProtocol: true,
   onSuccess: "pnpm run build:json-schema",
@@ -28,7 +27,6 @@ export default defineConfig({
       js: ".mjs",
     };
   },
-  plugins: [typiaRolldown],
   publint: true,
   sourcemap: false,
   treeshake: true,

--- a/typia-plugin.ts
+++ b/typia-plugin.ts
@@ -1,9 +1,7 @@
 import type { Options } from "@ryoppippi/unplugin-typia";
 
-import UnpluginTypiaRolldown from "@ryoppippi/unplugin-typia/rolldown";
 import UnpluginTypiaVite from "@ryoppippi/unplugin-typia/vite";
 
 const typiaOptions: Options | undefined = undefined;
 
-export const typiaRolldown = UnpluginTypiaRolldown(typiaOptions);
 export const typiaVite = UnpluginTypiaVite(typiaOptions);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Refactor
  - Streamlined build configuration to use the Vite integration by default.
  - Removed support for the Rolldown integration to simplify the plugin surface.
- Chores
  - Simplified user configuration: no manual plugin entry needed; Vite is auto-detected via a top-level flag.
  - Reduced public plugin exports to focus on the primary Vite integration.

Note: Projects relying on the Rolldown integration will need to migrate to the Vite-based setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->